### PR TITLE
DataExplorer - Create useFetch hook

### DIFF
--- a/src/dataexplorer/dataexplorer-application/.env
+++ b/src/dataexplorer/dataexplorer-application/.env
@@ -1,0 +1,2 @@
+REACT_APP_URL=http://localhost:3000
+REACT_APP_API_BASE_URL=https://spark-stu3.incendi.no

--- a/src/dataexplorer/dataexplorer-application/src/utils/hooks/useFetch.ts
+++ b/src/dataexplorer/dataexplorer-application/src/utils/hooks/useFetch.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+
+const useFetch = <T extends any>(
+    endpoint: string,
+    options: RequestInit = {},
+) => {
+    const [response, setResponse] = useState<T>();
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        let isSubscribed = true;
+
+        const fetchData = async () => {
+            try {
+                const res = await fetch(`${apiUrl}/${endpoint}`, options);
+                if (!res.ok) {
+                    throw new Error(`${res.status} ${res.statusText}`);
+                }
+                const json = await res.json();
+                if (!isSubscribed) {
+                    return;
+                }
+                setResponse(json);
+            } catch (error) {
+                setError(error.message);
+            }
+        };
+
+        fetchData();
+        return () => {
+            isSubscribed = false;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return { response, error };
+};
+
+export const apiUrl = process.env.REACT_APP_API_BASE_URL;
+
+export default useFetch;


### PR DESCRIPTION
To use the hook, import it and write
const { response, error } = useFetch< IYourInterface >('fhir/QuestionnaireResponse/_search');

The interface should match the structure of the response. You can fetch without an interface, but then we lose the purpose of TypeScript.

The URL should be changed. 
Examples of what you can fetch with different URLs: 
https://spark-stu3.incendi.no/swagger/index.html

