### PR TITLE
Marius/sort date

### DIFF
--- a/src/dataexplorer/dataexplorer-application/src/_variables.scss
+++ b/src/dataexplorer/dataexplorer-application/src/_variables.scss
@@ -1,0 +1,9 @@
+$background: #f0f2f5;
+$header: #3b6064;
+$elementHeader: #b6cacc;
+$rowColor: rgba(245, 241, 241, 0.523);
+$borderColor: lightGrey;
+$outline: #3b6064;
+$accent: #643b4f;
+
+$element2: #c5d3d0;

--- a/src/dataexplorer/dataexplorer-application/src/components/Dashboard/Dashboard.style.scss
+++ b/src/dataexplorer/dataexplorer-application/src/components/Dashboard/Dashboard.style.scss
@@ -1,3 +1,5 @@
+@import '../../variables';
+
 .search-container {
     margin-top: 10.625rem;
 
@@ -8,4 +10,19 @@
 
 p {
     margin-bottom: 0.4375rem;
+}
+.ant-input-affix-wrapper {
+    &:hover {
+        border-color: $header !important;
+    }
+    &:focus {
+        border-color: $elementHeader !important ;
+    }
+}
+.ant-input-affix-wrapper-focused {
+    box-shadow: 0 0 0 2px $elementHeader !important;
+    border-color: $header !important ;
+    &:focus {
+        border-color: $elementHeader !important ;
+    }
 }

--- a/src/dataexplorer/dataexplorer-application/src/components/Dashboard/Dashboard.style.scss
+++ b/src/dataexplorer/dataexplorer-application/src/components/Dashboard/Dashboard.style.scss
@@ -1,4 +1,4 @@
-@import '../../variables';
+@import '_variables';
 
 .search-container {
     margin-top: 10.625rem;

--- a/src/dataexplorer/dataexplorer-application/src/components/Dashboard/Dashboard.tsx
+++ b/src/dataexplorer/dataexplorer-application/src/components/Dashboard/Dashboard.tsx
@@ -18,12 +18,12 @@ const Dashboard = (props: { history: History }) => {
             <div className="search-container"></div>
             <Row gutter={[60, 40]} justify={'center'}>
                 <Col span={1000}>
-                    <p>Søk med personnummer for å finne en pasient</p>
                     <Search
                         style={{ width: 400 }}
                         className="search-bar"
-                        placeholder="Søk etter en pasient!"
+                        placeholder="Søk med personnummer for å finne en pasient"
                         onSearch={(value: string) => setPatientID(value)}
+                        allowClear={true}
                     />
                 </Col>
             </Row>

--- a/src/dataexplorer/dataexplorer-application/src/components/Navigation/Breadcrumbs/Breadcrumbs.style.scss
+++ b/src/dataexplorer/dataexplorer-application/src/components/Navigation/Breadcrumbs/Breadcrumbs.style.scss
@@ -1,11 +1,20 @@
+@import '../../../variables';
+
 .breadcrumbs-container {
     display: flex;
     flex-direction: row;
     flex-grow: 2;
     position: fixed;
+    padding: 5px;
 
     .breadcrumbs-item {
         color: black;
         padding-left: 0.1875rem;
+        font-size: 1.2rem;
+    }
+    .bread-icon {
+        font-size: 1.2rem !important;
+        margin-right: 0.3125rem;
+        color: $accent;
     }
 }

--- a/src/dataexplorer/dataexplorer-application/src/components/Navigation/Breadcrumbs/Breadcrumbs.style.scss
+++ b/src/dataexplorer/dataexplorer-application/src/components/Navigation/Breadcrumbs/Breadcrumbs.style.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@import '_variables';
 
 .breadcrumbs-container {
     display: flex;

--- a/src/dataexplorer/dataexplorer-application/src/components/Navigation/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/dataexplorer/dataexplorer-application/src/components/Navigation/Breadcrumbs/Breadcrumbs.tsx
@@ -34,14 +34,14 @@ const Breadcrumbs = ({
                 <Breadcrumb>
                     <Breadcrumb.Item>
                         <Link to="/" onClick={() => fromSchemeToHome()}>
-                            <HomeOutlined />
+                            <HomeOutlined className="bread-icon" />
                             <span className="breadcrumbs-item">Hjem</span>
                         </Link>
                     </Breadcrumb.Item>
                     {name !== '' && (
                         <Breadcrumb.Item onClick={() => fromSchemeToPatient()}>
                             <Link to="/Pasient">
-                                <UserOutlined />
+                                <UserOutlined className="bread-icon" />
                                 <span className="breadcrumbs-item">
                                     <b>{name}</b>
                                 </span>
@@ -50,7 +50,7 @@ const Breadcrumbs = ({
                     )}
                     {schemaNumber !== '' && (
                         <Breadcrumb.Item>
-                            <FileTextOutlined />
+                            <FileTextOutlined className="bread-icon" />
                             <span className="breadcrumbs-item">
                                 Skjema - {schemaNumber}
                             </span>

--- a/src/dataexplorer/dataexplorer-application/src/components/Navigation/Navigation.style.scss
+++ b/src/dataexplorer/dataexplorer-application/src/components/Navigation/Navigation.style.scss
@@ -1,3 +1,5 @@
+@import '../../variables';
+
 .site-layout-sub-header-background {
     position: fixed;
     z-index: 1;
@@ -7,13 +9,13 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    background-color: #3b6064;
-    border-bottom: solid lightgrey thin;
+    background-color: $header;
+    border-bottom: solid $borderColor thin;
 
     h1 {
         padding-right: 1.25rem;
         margin: 0;
-        border-right: solid lightgrey thin;
+        border-right: solid $borderColor thin;
         color: white;
         margin-bottom: 0;
     }
@@ -22,7 +24,7 @@
         color: white;
         display: flex;
         flex-direction: row;
-        border-left: solid lightgrey thin;
+        border-left: solid $borderColor thin;
 
         .header-avatar {
             margin-left: 1.25rem;
@@ -46,5 +48,5 @@
 }
 
 .content {
-    background-color: #f0f2f5;
+    background-color: $background;
 }

--- a/src/dataexplorer/dataexplorer-application/src/components/Navigation/Navigation.style.scss
+++ b/src/dataexplorer/dataexplorer-application/src/components/Navigation/Navigation.style.scss
@@ -1,4 +1,4 @@
-@import '../../variables';
+@import '_variables';
 
 .site-layout-sub-header-background {
     position: fixed;

--- a/src/dataexplorer/dataexplorer-application/src/components/Patient/PatientQuestionnaireResponses/PatientQuestionnaire/PatientView/PatientView.style.scss
+++ b/src/dataexplorer/dataexplorer-application/src/components/Patient/PatientQuestionnaireResponses/PatientQuestionnaire/PatientView/PatientView.style.scss
@@ -1,4 +1,4 @@
-@import '../../../../../variables';
+@import '_variables';
 
 .failed-container {
     margin-top: 12.5rem;
@@ -17,7 +17,6 @@
             margin-bottom: 0;
         }
     }
-
     .info-container {
         display: flex;
         justify-content: space-between;
@@ -27,29 +26,32 @@
         h4 {
             font-style: italic;
             font-weight: 150;
-            font-size: 1rem;
+            font-size: 1.25rem;
             margin-bottom: 0;
             margin-top: 0.8125rem;
         }
         .info-left {
             p {
                 font-weight: bold;
-                margin-left: 1.25rem;
+                margin-left: 1.6rem;
+                font-size: 1.25rem;
             }
         }
         .info-right {
             p {
                 font-weight: bold;
-                margin-left: 1.25rem;
+                margin-left: 1.6rem;
+                font-size: 1.25rem;
             }
         }
 
         .field-icon {
-            font-size: 0.875rem;
+            font-size: 1.25rem;
             margin-right: 0.375rem;
         }
         .unavailable-content {
-            margin-left: 1.25rem;
+            margin-left: 1.6rem;
+            font-size: 1.25rem;
         }
     }
 }

--- a/src/dataexplorer/dataexplorer-application/src/components/Patient/PatientQuestionnaireResponses/PatientQuestionnaire/PatientView/PatientView.style.scss
+++ b/src/dataexplorer/dataexplorer-application/src/components/Patient/PatientQuestionnaireResponses/PatientQuestionnaire/PatientView/PatientView.style.scss
@@ -1,13 +1,15 @@
+@import '../../../../../variables';
+
 .failed-container {
     margin-top: 12.5rem;
 }
 
 .patient-card {
-    margin-top: (1.875rem!important);
-    cursor: auto;
+    margin-top: 1.875rem !important;
+    cursor: default;
 
     .ant-card-head {
-        background-color: #f7fbff !important;
+        background-color: $elementHeader !important;
         display: flex;
         justify-content: center;
 
@@ -19,15 +21,35 @@
     .info-container {
         display: flex;
         justify-content: space-between;
-
         span {
             font-weight: bold;
         }
         h4 {
             font-style: italic;
             font-weight: 150;
+            font-size: 1rem;
             margin-bottom: 0;
             margin-top: 0.8125rem;
+        }
+        .info-left {
+            p {
+                font-weight: bold;
+                margin-left: 1.25rem;
+            }
+        }
+        .info-right {
+            p {
+                font-weight: bold;
+                margin-left: 1.25rem;
+            }
+        }
+
+        .field-icon {
+            font-size: 0.875rem;
+            margin-right: 0.375rem;
+        }
+        .unavailable-content {
+            margin-left: 1.25rem;
         }
     }
 }
@@ -37,13 +59,29 @@
 
     .ant-table-thead {
         th {
-            background-color: #f7fbff !important;
+            background-color: $elementHeader !important;
         }
     }
     .ant-table-tbody {
         .table-row-dark {
-            background-color: rgba(245, 241, 241, 0.523);
+            background-color: $rowColor;
         }
         cursor: pointer;
+    }
+
+    .mini {
+        .ant-pagination-item {
+            a {
+                &:hover {
+                    color: $elementHeader;
+                }
+            }
+        }
+        .ant-pagination-item-active {
+            border-color: $elementHeader;
+            a {
+                color: green;
+            }
+        }
     }
 }

--- a/src/dataexplorer/dataexplorer-application/src/components/Patient/PatientQuestionnaireResponses/PatientQuestionnaire/PatientView/PatientView.tsx
+++ b/src/dataexplorer/dataexplorer-application/src/components/Patient/PatientQuestionnaireResponses/PatientQuestionnaire/PatientView/PatientView.tsx
@@ -4,6 +4,13 @@ import { Row, Col, Card, Table, Typography } from 'antd';
 import dayjs from 'dayjs';
 import './PatientView.style.scss';
 import { useHistory } from 'react-router-dom';
+import {
+    IdcardOutlined,
+    ManOutlined,
+    HourglassOutlined,
+    MobileOutlined,
+    HomeOutlined,
+} from '@ant-design/icons';
 
 const PatientView = (props: {
     patient: IPatient;
@@ -62,68 +69,100 @@ const PatientView = (props: {
     return (
         <>
             <Row gutter={[1, 40]} justify="center">
-                <Col span={12}>
+                <Col span={8}>
                     <Card
                         key={props.patient.id}
                         className="patient-card"
                         title={<Title level={4}>{name}</Title>}
                         type="inner"
-                        hoverable
                         bordered
                     >
                         <div className="info-container">
                             <div className="info-left">
-                                <h4>Personnummer:</h4>
-                                <span>{props.patient.identifier[0].value}</span>
-                                <h4>Kjønn:</h4>
-                                <span>
-                                    {props.patient.gender !== 'male' &&
-                                    props.patient.gender !== 'female'
-                                        ? props.patient.gender
-                                              .charAt(0)
-                                              .toUpperCase() +
-                                          props.patient.gender.slice(1)
-                                        : props.patient.gender === 'male'
-                                        ? 'Mann'
-                                        : 'Kvinne'}
-                                </span>
-                                <h4>Alder:</h4>
-                                <span>
-                                    {props.patient.birthDate !== undefined ? (
-                                        calcAge()
-                                    ) : (
-                                        <div>Ikke oppgitt</div>
-                                    )}
-                                </span>
+                                <div className="item-container">
+                                    <h4>
+                                        <IdcardOutlined className="field-icon" />
+                                        Personnummer:
+                                    </h4>
+
+                                    <p>{props.patient.identifier[0].value}</p>
+                                </div>
+                                <div className="item-container">
+                                    <h4>
+                                        <ManOutlined className="field-icon" />
+                                        Kjønn:
+                                    </h4>
+                                    <p>
+                                        {props.patient.gender !== 'male' &&
+                                        props.patient.gender !== 'female'
+                                            ? props.patient.gender
+                                                  .charAt(0)
+                                                  .toUpperCase() +
+                                              props.patient.gender.slice(1)
+                                            : props.patient.gender === 'male'
+                                            ? 'Mann'
+                                            : 'Kvinne'}
+                                    </p>
+                                </div>
+                                <div className="item-container">
+                                    <h4>
+                                        <HourglassOutlined className="field-icon" />
+                                        Alder:
+                                    </h4>
+                                    <p>
+                                        {props.patient.birthDate !==
+                                        undefined ? (
+                                            calcAge()
+                                        ) : (
+                                            <div>Ikke oppgitt</div>
+                                        )}
+                                    </p>
+                                </div>
                             </div>
-
+                            {console.log(props.patient)}
                             <div className="info-right">
-                                <h4>Adresse: </h4>
-
-                                {props.patient?.address?.[0]?.line !==
-                                undefined ? (
-                                    <span>
-                                        {props.patient?.address?.[0]?.line?.[0]}
-                                    </span>
-                                ) : (
-                                    <div className="unavailable-content">
-                                        Ikke oppgitt
-                                    </div>
-                                )}
-                                <h4>Telefon: </h4>
-                                {props.patient?.telecom?.[0]?.value !==
-                                undefined ? (
-                                    <span>
-                                        {props.patient?.telecom?.[0]?.value}
-                                    </span>
-                                ) : (
-                                    <div className="unavailable-content">
-                                        Ikke oppgitt
-                                    </div>
-                                )}
+                                <div className="item-container">
+                                    <h4>
+                                        <HomeOutlined className="field-icon" />
+                                        Adresse:
+                                    </h4>
+                                    {props.patient?.address?.[0]?.line !==
+                                    undefined ? (
+                                        <p>
+                                            {
+                                                props.patient?.address?.[0]
+                                                    ?.line?.[0]
+                                            }
+                                        </p>
+                                    ) : (
+                                        <div className="unavailable-content">
+                                            Ikke oppgitt
+                                        </div>
+                                    )}
+                                </div>
+                                <div className="item-container">
+                                    <h4>
+                                        <MobileOutlined className="field-icon" />
+                                        Telefon:
+                                    </h4>
+                                    {props.patient?.telecom?.[0]?.value !==
+                                    undefined ? (
+                                        <p>
+                                            {props.patient?.telecom?.[0]?.value}
+                                        </p>
+                                    ) : (
+                                        <div className="unavailable-content">
+                                            Ikke oppgitt
+                                        </div>
+                                    )}
+                                </div>
                             </div>
                         </div>
                     </Card>
+                </Col>
+            </Row>
+            <Row justify="center">
+                <Col span={12}>
                     <Table
                         key={'Patient Questionnaire Response Key'}
                         rowKey={(record) =>

--- a/src/dataexplorer/dataexplorer-application/src/components/Patient/PatientQuestionnaireResponses/PatientQuestionnaire/PatientView/PatientView.tsx
+++ b/src/dataexplorer/dataexplorer-application/src/components/Patient/PatientQuestionnaireResponses/PatientQuestionnaire/PatientView/PatientView.tsx
@@ -7,7 +7,8 @@ import { useHistory } from 'react-router-dom';
 import {
     IdcardOutlined,
     ManOutlined,
-    HourglassOutlined,
+    WomanOutlined,
+    CrownOutlined,
     MobileOutlined,
     HomeOutlined,
 } from '@ant-design/icons';
@@ -89,7 +90,11 @@ const PatientView = (props: {
                                 </div>
                                 <div className="item-container">
                                     <h4>
-                                        <ManOutlined className="field-icon" />
+                                        {props.patient.gender === 'male' ? (
+                                            <ManOutlined className="field-icon" />
+                                        ) : (
+                                            <WomanOutlined className="field-icon" />
+                                        )}
                                         Kjønn:
                                     </h4>
                                     <p>
@@ -106,7 +111,7 @@ const PatientView = (props: {
                                 </div>
                                 <div className="item-container">
                                     <h4>
-                                        <HourglassOutlined className="field-icon" />
+                                        <CrownOutlined className="field-icon" />
                                         Alder:
                                     </h4>
                                     <p>
@@ -114,12 +119,13 @@ const PatientView = (props: {
                                         undefined ? (
                                             calcAge()
                                         ) : (
-                                            <div>Ikke oppgitt</div>
+                                            <div className="unavailable-content">
+                                                Ikke oppgitt
+                                            </div>
                                         )}
                                     </p>
                                 </div>
                             </div>
-                            {console.log(props.patient)}
                             <div className="info-right">
                                 <div className="item-container">
                                     <h4>

--- a/src/dataexplorer/dataexplorer-application/src/components/Patient/PatientQuestionnaireResponses/PatientQuestionnaire/PatientView/PatientView.tsx
+++ b/src/dataexplorer/dataexplorer-application/src/components/Patient/PatientQuestionnaireResponses/PatientQuestionnaire/PatientView/PatientView.tsx
@@ -35,6 +35,12 @@ const PatientView = (props: {
         props.patient.name[0].given[0] + ' ' + props.patient.name[0].family;
     const columns = [
         {
+            title: 'ID',
+            dataIndex: 'id',
+            key: 'id',
+            sorter: (a: any, b: any) => a.id - b.id,
+        },
+        {
             title: 'Skjemanavn',
             dataIndex: 'schemaName',
             key: 'schemaName',
@@ -43,12 +49,8 @@ const PatientView = (props: {
             title: 'Innsendt',
             dataIndex: 'submitted',
             key: 'submitted',
-        },
-        {
-            title: 'ID',
-            dataIndex: 'id',
-            key: 'id',
-            sorter: (a: any, b: any) => a.id - b.id,
+            sorter: (a: any, b: any) =>
+                dayjs(a.submitted).unix() - dayjs(b.submitted).unix(),
         },
     ];
 

--- a/src/dataexplorer/dataexplorer-application/src/index.scss
+++ b/src/dataexplorer/dataexplorer-application/src/index.scss
@@ -1,3 +1,5 @@
+@import './variables';
+
 body {
     margin: 0;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
@@ -13,7 +15,13 @@ code {
         monospace;
 }
 
-#root,
-#root > section {
-    height: 100%;
+#root {
+    &,
+    section {
+        height: 100%;
+    }
+}
+
+html {
+    --antd-wave-shadow-color: $outline;
 }

--- a/src/dataexplorer/dataexplorer-application/src/index.tsx
+++ b/src/dataexplorer/dataexplorer-application/src/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './components/App';
 import { BrowserRouter as Router } from 'react-router-dom';
-import './index.css';
+import './index.scss';
 
 ReactDOM.render(
     <Router>


### PR DESCRIPTION
**Fix**
- Styles now override Ant-defaults.
- index.css -> index.scss.
- DOM now has correct nesting of elements.

**Changes**
- Changed every color-field to us SCSS variables.
- Changed size of Card to diversify from table, and clear whitespace.
- Introduced accent color and changed some elements to use it.
- Increased visibility of breadcrumbs.
- Updated colorscheme
- Removed double search-text (we should adhere to the field moving up above the box when clicked/typed)

**Add**
- Implemented SCSS variables for colors across all SCSS files.
- Sorting of table on date now works.
- Icons to Card to alleviate whitespace and make it less boring.