### PR TITLE
Redirect all requests to SPA

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+# Netlify redirects
+/*    /   200


### PR DESCRIPTION
To prevent 404 when going straight to a route, ref [netlify docs](https://docs.netlify.com/routing/redirects/rewrites-proxies/#limitations)