### PR TITLE
add definition field

### DIFF
--- a/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
+++ b/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
@@ -286,6 +286,16 @@ const AdvancedQuestionOptions = ({ item, parentArray }: AdvancedQuestionOptionsP
                     </FormField>
                 </div>
             )}
+            <div className="horizontal full">
+                <FormField label={t('Definition')} isOptional>
+                    <InputField
+                        defaultValue={item.definition}
+                        onBlur={(e) => {
+                            dispatch(updateItemAction(item.linkId, IItemProperty.definition, e.target.value));
+                        }}
+                    />
+                </FormField>
+            </div>
             {canTypeHaveHelp(item) && (
                 <div>
                     <FormField>


### PR DESCRIPTION
Hello,
I'm working on a fhir project which use questionnaires.
Your interface respond to most of our needs but one : we use the definition field with the operations $populate and $apply.
best,

Luc Chatty