### PR TITLE
Proper support for choice itemControl.RadioButton

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-  "typescript.tsdk": "node_modules\\typescript\\lib"
+  "typescript.tsdk": "node_modules\\typescript\\lib",
+  "eslint.enable": true,
+  "eslint.alwaysShowStatus": true,
+  "eslint.lintTask.enable": true,
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+  "editor.formatOnSave": true,
+  "prettier.requireConfig": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/src/components/Question/QuestionType/Choice.tsx
+++ b/src/components/Question/QuestionType/Choice.tsx
@@ -11,11 +11,16 @@ import { QuestionnaireItem, QuestionnaireItemAnswerOption } from '../../../types
 import Btn from '../../Btn/Btn';
 import { IExtentionType, IItemProperty, IQuestionnaireItemType } from '../../../types/IQuestionnareItemType';
 import { TreeContext } from '../../../store/treeStore/treeStore';
-import { checkboxExtension, dropdownExtension } from '../../../helpers/QuestionHelper';
+import { checkboxExtension, dropdownExtension, radiobuttonExtension } from '../../../helpers/QuestionHelper';
 import { removeItemAttributeAction, updateItemAction } from '../../../store/treeStore/treeActions';
 
 import UriField from '../../FormField/UriField';
-import { isItemControlCheckbox, isItemControlDropDown, ItemControlType } from '../../../helpers/itemControl';
+import {
+    isItemControlCheckbox,
+    isItemControlDropDown,
+    isItemControlRadioButton,
+    ItemControlType,
+} from '../../../helpers/itemControl';
 import { removeItemExtension, setItemExtension } from '../../../helpers/extensionHelper';
 import FormField from '../../FormField/FormField';
 import ChoiceTypeSelect from './ChoiceTypeSelect';
@@ -39,6 +44,8 @@ const Choice = ({ item }: Props): JSX.Element => {
             setItemExtension(item, checkboxExtension, dispatch);
         } else if (type === ItemControlType.dropdown && !isItemControlDropDown(item)) {
             setItemExtension(item, dropdownExtension, dispatch);
+        } else if (type === ItemControlType.radioButton && !isItemControlRadioButton(item)) {
+            setItemExtension(item, radiobuttonExtension, dispatch);
         }
     };
 

--- a/src/components/Question/QuestionType/ChoiceTypeSelect.tsx
+++ b/src/components/Question/QuestionType/ChoiceTypeSelect.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { isItemControlCheckbox, isItemControlDropDown, ItemControlType } from '../../../helpers/itemControl';
+import {
+    isItemControlCheckbox,
+    isItemControlDropDown,
+    isItemControlRadioButton,
+    ItemControlType,
+} from '../../../helpers/itemControl';
 import { QuestionnaireItem } from '../../../types/fhir';
 import FormField from '../../FormField/FormField';
 import RadioBtn from '../../RadioBtn/RadioBtn';
@@ -19,8 +24,10 @@ const ChoiceTypeSelect = ({ item, dispatchExtentionUpdate }: Props): JSX.Element
             return ItemControlType.checkbox;
         } else if (isItemControlDropDown(item)) {
             return ItemControlType.dropdown;
+        } else if (isItemControlRadioButton(item)) {
+            return ItemControlType.radioButton;
         }
-        return ItemControlType.radioButton;
+        return ItemControlType.dynamic;
     };
 
     return (
@@ -32,6 +39,10 @@ const ChoiceTypeSelect = ({ item, dispatchExtentionUpdate }: Props): JSX.Element
                     }}
                     checked={getSelectedItemControlValue()}
                     options={[
+                        {
+                            code: ItemControlType.dynamic,
+                            display: t('Dynamic'),
+                        },
                         {
                             code: ItemControlType.radioButton,
                             display: t('Radio buttons'),

--- a/src/helpers/QuestionHelper.ts
+++ b/src/helpers/QuestionHelper.ts
@@ -47,6 +47,7 @@ export const quantityUnitTypes = [
 
 export const checkboxExtension = createItemControlExtension(ItemControlType.checkbox);
 export const dropdownExtension = createItemControlExtension(ItemControlType.dropdown);
+export const radiobuttonExtension = createItemControlExtension(ItemControlType.radioButton);
 
 export const enableWhenOperatorBoolean: ValueSetComposeIncludeConcept[] = [
     {

--- a/src/helpers/itemControl.ts
+++ b/src/helpers/itemControl.ts
@@ -15,6 +15,7 @@ export enum ItemControlType {
     yearMonth = 'yearMonth',
     year = 'year',
     receiverComponent = 'receiver-component',
+    dynamic = 'dynamic',
 }
 
 export const createItemControlExtension = (itemControlType: ItemControlType): Extension => {
@@ -56,6 +57,10 @@ export const isItemControlReceiverComponent = (item: QuestionnaireItem): boolean
 
 export const isItemControlDropDown = (item: QuestionnaireItem): boolean => {
     return getItemControlType(item) === ItemControlType.dropdown;
+};
+
+export const isItemControlRadioButton = (item: QuestionnaireItem): boolean => {
+    return getItemControlType(item) === ItemControlType.radioButton;
 };
 
 export const isItemControlAutocomplete = (item: QuestionnaireItem): boolean => {

--- a/src/locales/fr-FR/translation.json
+++ b/src/locales/fr-FR/translation.json
@@ -345,5 +345,6 @@
     "Upload ValueSet(s)": "Télécharger des valeurs",
     "Connect to print version (binary)": "Connectez-vous à la version imprimable (binaire)",
     "For example Binary/35": "ex: Binary/35",
-    "Print version": "Version imprimée"
+    "Print version": "Version imprimée",
+    "Dynamic": "Dynamique"
 }

--- a/src/locales/nb-NO/translation.json
+++ b/src/locales/nb-NO/translation.json
@@ -345,5 +345,6 @@
     "Upload ValueSet(s)": "Last opp verdisett",
     "Connect to print version (binary)": "Koble til PDF-skjema (binary)",
     "For example Binary/35": "F.eks Binary/35",
-    "Print version": "Utskriftsversjon"
+    "Print version": "Utskriftsversjon",
+    "Dynamic": "Dynamisk"
 }


### PR DESCRIPTION
- ItemControle.Radiobutton choice now enforces rendering of the item as
  radiobuttons.
- Renamed the old radiobutton choice to dynamic in order to preserve the
  dynamic behaviour of auto-selecting between radio and dropdown
  depending on the number of options.
- Added eslint and prettier config for vs code