### PR TITLE
Fixed bug by adding translations for the update-button in FormPreview

### DIFF
--- a/src/components/Refero/FormFillerPreview.tsx
+++ b/src/components/Refero/FormFillerPreview.tsx
@@ -6,7 +6,7 @@ import thunk from 'redux-thunk';
 
 import { generateQuestionnaireForPreview } from '../../helpers/generateQuestionnaire';
 import { getLanguagesInUse, INITIAL_LANGUAGE } from '../../helpers/LanguageHelper';
-import { getResources, getButtonText } from '../../locales/referoResources';
+import { getResources } from '../../locales/referoResources';
 import rootReducer from '@helsenorge/refero/reducers';
 import { TreeState } from '../../store/treeStore/treeStore';
 
@@ -108,7 +108,7 @@ const FormFillerPreview = ({ showFormFiller, language, state, changeReferoKey }:
                             />
                             <button className="changePreviewButton" onClick={changeReferoKey}>
                                 <div className="changePreviewButton-content">
-                                    {getButtonText(language || '')}
+                                    {t('Update')}
                                     <div className="changePreviewButton-icon">
                                         <Icon svgIcon={CheckFill} size={24} color="white"></Icon>
                                     </div>

--- a/src/locales/fr-FR/translation.json
+++ b/src/locales/fr-FR/translation.json
@@ -367,5 +367,6 @@
     "Print version": "Version imprimée",
     "Dynamic": "Dynamique",
     "Open item links in same tab": "Ouvrir les liens des éléments dans le même onglet",
-    "Open all links in same tab": "Ouvrir tous les liens dans le même onglet"
+    "Open all links in same tab": "Ouvrir tous les liens dans le même onglet",
+    "Update": "Mettre à jour"
 }

--- a/src/locales/nb-NO/translation.json
+++ b/src/locales/nb-NO/translation.json
@@ -367,5 +367,6 @@
     "Print version": "Utskriftsversjon",
     "Dynamic": "Dynamisk",
     "Open item links in same tab": "Åpne lenker i samme vindu",
-    "Open all links in same tab": "Åpne alle lenker i samme vindu"
+    "Open all links in same tab": "Åpne alle lenker i samme vindu",
+    "Update": "Oppdater"
 }

--- a/src/locales/referoResources.tsx
+++ b/src/locales/referoResources.tsx
@@ -296,13 +296,3 @@ export const getResources = (language: string): { [id: string]: string } => {
         adresseKomponent_loadError: 'Teknisk feil: kunne ikke laste liste over mottakere',
     };
 };
-
-export const getButtonText = (language: string): string => {
-    if (language === 'en-GB') {
-        return 'Apply';
-    }
-    if (language === 'fr-FR') {
-        return 'Appliquer';
-    }
-    return 'Oppdater';
-};


### PR DESCRIPTION
The bug was that the text in the update-button used the same language as the form, but not the form builder. I fixed this bug by removing the old getButtonText method and added translations for the text "Update" in the translation files.