### PR TITLE
Bedre markering i PDF av oppsummeringsseksjon

### DIFF
--- a/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
+++ b/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
@@ -17,7 +17,14 @@ import SwitchBtn from '../SwitchBtn/SwitchBtn';
 import Initial from './Initial/Initial';
 import FormField from '../FormField/FormField';
 import MarkdownEditor from '../MarkdownEditor/MarkdownEditor';
-import { createItemControlExtension, getHelpText, isItemControlHelp, ItemControlType } from '../../helpers/itemControl';
+import {
+    getHelpText,
+    isItemControlHelp,
+    isItemControlSummary,
+    isItemControlSummaryContainer,
+    ItemControlType,
+    setItemControlExtension,
+} from '../../helpers/itemControl';
 import GuidanceAction from './Guidance/GuidanceAction';
 import GuidanceParam from './Guidance/GuidanceParam';
 import FhirPathSelect from './FhirPathSelect/FhirPathSelect';
@@ -117,9 +124,8 @@ const AdvancedQuestionOptions = ({ item, parentArray }: AdvancedQuestionOptionsP
     const getRepeatsText = item?.extension?.find((x) => x.url === IExtentionType.repeatstext)?.valueString ?? '';
     const minOccurs = item?.extension?.find((x) => x.url === IExtentionType.minOccurs)?.valueInteger;
     const maxOccurs = item?.extension?.find((x) => x.url === IExtentionType.maxOccurs)?.valueInteger;
-    const hasSummaryExtension = !!item?.extension?.find((x) =>
-        x.valueCodeableConcept?.coding?.filter((y) => y.code === ItemControlType.summary),
-    );
+    const hasSummaryExtension = isItemControlSummary(item);
+    const hasSummaryContainerExtension = isItemControlSummaryContainer(item);
 
     const helpTextItem = getHelpTextItem();
     const isHiddenItem = item.extension?.some((ext) => ext.url === IExtentionType.hidden && ext.valueBoolean);
@@ -320,20 +326,26 @@ const AdvancedQuestionOptions = ({ item, parentArray }: AdvancedQuestionOptionsP
             <GuidanceAction item={item} />
             <GuidanceParam item={item} />
             {canTypeHaveSummary(item) && (
-                <FormField>
-                    <SwitchBtn
-                        onChange={() => {
-                            if (hasSummaryExtension) {
-                                removeExtension(IExtentionType.itemControl);
-                            } else {
-                                const newExtension = createItemControlExtension(ItemControlType.summary);
-                                handleExtension(newExtension);
-                            }
-                        }}
-                        value={hasSummaryExtension}
-                        label={t('Enable summary')}
-                    />
-                </FormField>
+                <div>
+                    <FormField>
+                        <SwitchBtn
+                            onChange={() => {
+                                setItemControlExtension(item, ItemControlType.summary, dispatch);
+                            }}
+                            value={hasSummaryExtension}
+                            label={t('Put in PDF first')}
+                        />
+                    </FormField>
+                    <FormField>
+                        <SwitchBtn
+                            onChange={() => {
+                                setItemControlExtension(item, ItemControlType.summaryContainer, dispatch);
+                            }}
+                            value={hasSummaryContainerExtension}
+                            label={t('Enable summary')}
+                        />
+                    </FormField>
+                </div>
             )}
             <FormField label={t('Save capabilities')}>
                 <RadioBtn

--- a/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
+++ b/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
@@ -342,7 +342,7 @@ const AdvancedQuestionOptions = ({ item, parentArray }: AdvancedQuestionOptionsP
                                 setItemControlExtension(item, ItemControlType.summaryContainer, dispatch);
                             }}
                             value={hasSummaryContainerExtension}
-                            label={t('Enable summary group')}
+                            label={t('Mark group in PDF')}
                         />
                     </FormField>
                 </div>

--- a/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
+++ b/src/components/AdvancedQuestionOptions/AdvancedQuestionOptions.tsx
@@ -342,7 +342,7 @@ const AdvancedQuestionOptions = ({ item, parentArray }: AdvancedQuestionOptionsP
                                 setItemControlExtension(item, ItemControlType.summaryContainer, dispatch);
                             }}
                             value={hasSummaryContainerExtension}
-                            label={t('Enable summary')}
+                            label={t('Enable summary group')}
                         />
                     </FormField>
                 </div>

--- a/src/locales/fr-FR/translation.json
+++ b/src/locales/fr-FR/translation.json
@@ -31,7 +31,7 @@
     "Reset to original value": "Réinitialiser à la valeur originale",
     "Enable help button": "Activer le bouton d'aide",
     "Enter a helping text": "Etrez le texte d'aide",
-    "Enable summary group": "Activer le groupe récapitulatif",
+    "Mark group in PDF": "Marquer le groupe dans le PDF",
     "Put in PDF first": "Mettre d'abord en PDF",
     "Here you will find a summary of questionnaire elements. Drag a component here to start building this Questionnaire": "Ici vous trouverez un résumé des élements du questionnaire. Faites glisser un composant ici pour commencer à construire ce Questionnaire",
     "Create element": "Créer élément",

--- a/src/locales/fr-FR/translation.json
+++ b/src/locales/fr-FR/translation.json
@@ -31,7 +31,7 @@
     "Reset to original value": "Réinitialiser à la valeur originale",
     "Enable help button": "Activer le bouton d'aide",
     "Enter a helping text": "Etrez le texte d'aide",
-    "Enable summary": "Activer le résumé",
+    "Enable summary group": "Activer le groupe récapitulatif",
     "Put in PDF first": "Mettre d'abord en PDF",
     "Here you will find a summary of questionnaire elements. Drag a component here to start building this Questionnaire": "Ici vous trouverez un résumé des élements du questionnaire. Faites glisser un composant ici pour commencer à construire ce Questionnaire",
     "Create element": "Créer élément",

--- a/src/locales/fr-FR/translation.json
+++ b/src/locales/fr-FR/translation.json
@@ -32,6 +32,7 @@
     "Enable help button": "Activer le bouton d'aide",
     "Enter a helping text": "Etrez le texte d'aide",
     "Enable summary": "Activer le résumé",
+    "Put in PDF first": "Mettre d'abord en PDF",
     "Here you will find a summary of questionnaire elements. Drag a component here to start building this Questionnaire": "Ici vous trouverez un résumé des élements du questionnaire. Faites glisser un composant ici pour commencer à construire ce Questionnaire",
     "Create element": "Créer élément",
     "Add top-level element": "Ajouter un élément de haut niveau",

--- a/src/locales/nb-NO/translation.json
+++ b/src/locales/nb-NO/translation.json
@@ -31,7 +31,7 @@
     "Reset to original value": "Sett tilbake til opprinnelig verdi",
     "Enable help button": "Skru på hjelpeikon",
     "Enter a helping text": "Skriv en hjelpende tekst",
-    "Enable summary group": "Skru på oppsummeringsgruppe",
+    "Mark group in PDF": "Marker gruppe i PDF",
     "Put in PDF first": "Legg først i PDF",
     "Here you will find a summary of questionnaire elements. Drag a component here to start building this Questionnaire": "Her vil du finne en oversikt over elementene i skjemaet. Dra komponenter hit for å bygge skjema",
     "Create element": "Opprett element",

--- a/src/locales/nb-NO/translation.json
+++ b/src/locales/nb-NO/translation.json
@@ -32,6 +32,7 @@
     "Enable help button": "Skru på hjelpeikon",
     "Enter a helping text": "Skriv en hjelpende tekst",
     "Enable summary": "Skru på oppsummering",
+    "Put in PDF first": "Legg først i PDF",
     "Here you will find a summary of questionnaire elements. Drag a component here to start building this Questionnaire": "Her vil du finne en oversikt over elementene i skjemaet. Dra komponenter hit for å bygge skjema",
     "Create element": "Opprett element",
     "Add top-level element": "Legg til element på toppnivå",

--- a/src/locales/nb-NO/translation.json
+++ b/src/locales/nb-NO/translation.json
@@ -31,7 +31,7 @@
     "Reset to original value": "Sett tilbake til opprinnelig verdi",
     "Enable help button": "Skru på hjelpeikon",
     "Enter a helping text": "Skriv en hjelpende tekst",
-    "Enable summary": "Skru på oppsummering",
+    "Enable summary group": "Skru på oppsummeringsgruppe",
     "Put in PDF first": "Legg først i PDF",
     "Here you will find a summary of questionnaire elements. Drag a component here to start building this Questionnaire": "Her vil du finne en oversikt over elementene i skjemaet. Dra komponenter hit for å bygge skjema",
     "Create element": "Opprett element",


### PR DESCRIPTION
For å lette navigering for mottaker, er det ønskelig å kunne markere grupper som oppsummeringsseksjoner som markeres spesielt i PDF.

Oppsummeringsgrupper skal kunne angis på elementer av type gruppe i Skjemabyggeren.
**Oppgaver**
Valg i skjemabygger for å kunne angi at en gruppe er en oppsummeringsseksjon

Eksisterende valg for "Skru på oppsummering" på grupper i Skjemabyggeren skal endre navn
Endres til "Legg først i PDF"
Gjelder "summary" i itemControl,