### PR TITLE
Form filler: Copy or move data fields to a summary function (Del 4)

### DIFF
--- a/src/components/AdvancedQuestionOptions/CalculatedExpression/CalculatedExpression.tsx
+++ b/src/components/AdvancedQuestionOptions/CalculatedExpression/CalculatedExpression.tsx
@@ -6,6 +6,7 @@ import FormField from '../../FormField/FormField';
 
 type CalculatedExpressionProps = {
     item: QuestionnaireItem;
+    disabled?: boolean;
     updateExtension: (extension: Extension) => void;
     removeExtension: (extensionType: IExtentionType) => void;
 };
@@ -28,7 +29,7 @@ const CalculatedExpression = (props: CalculatedExpressionProps): JSX.Element => 
         props.item.extension?.find((ext) => ext.url === IExtentionType.calculatedExpression)?.valueString || '';
     return (
         <FormField label={t('Calculation formula')}>
-            <textarea defaultValue={calculatedExpression} onBlur={handleBlur} />
+            <textarea defaultValue={calculatedExpression} onBlur={handleBlur} disabled={props.disabled} />
         </FormField>
     );
 };

--- a/src/components/AdvancedQuestionOptions/CopyFrom/CopyFrom.tsx
+++ b/src/components/AdvancedQuestionOptions/CopyFrom/CopyFrom.tsx
@@ -1,0 +1,111 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TreeContext } from '../../../store/treeStore/treeStore';
+import {
+    QuestionnaireItem,
+    ValueSetComposeIncludeConcept,
+    Extension,
+    QuestionnaireItemEnableWhen,
+} from '../../../types/fhir';
+import FormField from '../../FormField/FormField';
+import Select from '../../Select/Select';
+import SwitchBtn from '../../SwitchBtn/SwitchBtn';
+import { ItemControlType, setItemControlExtension } from '../../../helpers/itemControl';
+import { IItemProperty, IExtentionType, IOperator } from '../../../types/IQuestionnareItemType';
+import { setItemExtension, removeItemExtension, getExtensionStringValue } from '../../../helpers/extensionHelper';
+import { updateItemAction } from '../../../store/treeStore/treeActions';
+
+type CopyFromProps = {
+    item: QuestionnaireItem;
+    conditionalArray: ValueSetComposeIncludeConcept[];
+    isDataReceiver: boolean;
+    canTypeBeReadonly: boolean;
+    dataReceiverStateChanger: React.Dispatch<React.SetStateAction<boolean>>;
+    getItem: (linkId: string) => QuestionnaireItem;
+};
+
+const getLinkIdFromValueString = (item: QuestionnaireItem): string => {
+    const extensionValueString = getExtensionStringValue(item, IExtentionType.copyExpression) ?? '';
+    const startIndex = extensionValueString.indexOf("'") + 1;
+    const endIndex = extensionValueString.indexOf("')");
+    return extensionValueString.substring(startIndex, endIndex);
+};
+
+const CopyFrom = (props: CopyFromProps): JSX.Element => {
+    const { t } = useTranslation();
+    const { dispatch } = useContext(TreeContext);
+    const getSelectedValue = () => props.conditionalArray.find((f) => f.code === getLinkIdFromValueString(props.item));
+    const [selectedValue, setSelectedvalue] = useState(getSelectedValue());
+    const questionsOptions = props.conditionalArray.filter((f) => props.getItem(f.code).type === props.item.type);
+
+    const removeCopyExpression = () => removeItemExtension(props.item, IExtentionType.copyExpression, dispatch);
+    const updateReadonlyItem = (value: boolean) => {
+        if (props.canTypeBeReadonly) {
+            dispatch(updateItemAction(props.item.linkId, IItemProperty.readOnly, value));
+        }
+    };
+    const updateEnableWhen = () => {
+        const enableWhen = selectedValue
+            ? [
+                  {
+                      answerBoolean: true,
+                      question: selectedValue?.code,
+                      operator: IOperator.exists,
+                  } as QuestionnaireItemEnableWhen,
+              ]
+            : [];
+        dispatch(updateItemAction(props.item.linkId, IItemProperty.enableWhen, enableWhen));
+    };
+
+    useEffect(() => {
+        if (!props.isDataReceiver) {
+            removeCopyExpression();
+            setSelectedvalue(undefined);
+        }
+        updateReadonlyItem(props.isDataReceiver);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [props.isDataReceiver]);
+
+    useEffect(() => {
+        updateEnableWhen();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedValue]);
+
+    const onChangeSwitchBtn = async (): Promise<void> => {
+        setItemControlExtension(props.item, ItemControlType.dataReceiver, dispatch);
+        props.dataReceiverStateChanger(!props.isDataReceiver);
+    };
+
+    const onChangeSelect = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+        const extension: Extension = {
+            url: IExtentionType.copyExpression,
+            valueString: `QuestionnaireResponse.descendants().where(linkId='${event.target.value}').answer.value`,
+        };
+        setItemExtension(props.item, extension, dispatch);
+        setSelectedvalue(props.conditionalArray.find((f) => f.code === event.target.value));
+    };
+
+    return (
+        <div className="horizontal equal">
+            <FormField>
+                <SwitchBtn
+                    onChange={onChangeSwitchBtn}
+                    value={props.isDataReceiver}
+                    label={t('Retrieve input data from field')}
+                />
+            </FormField>
+            {props.isDataReceiver && (
+                <FormField label={t('Select earlier question:')}>
+                    <Select
+                        placeholder={t('Choose question:')}
+                        options={questionsOptions}
+                        value={selectedValue?.code}
+                        onChange={(event) => onChangeSelect(event)}
+                    />
+                </FormField>
+            )}
+        </div>
+    );
+};
+
+export default CopyFrom;

--- a/src/components/Question/Question.css
+++ b/src/components/Question/Question.css
@@ -108,7 +108,7 @@
 }
 
 .horizontal.equal {
-    min-height: 81px;
+    min-height: 50px;
 }
 
 .horizontal.equal > div {

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -230,7 +230,12 @@ const Question = (props: QuestionProps): JSX.Element => {
                     <Codes linkId={props.item.linkId} itemValidationErrors={props.itemValidationErrors} />
                 </Accordion>
                 <Accordion title={t('Advanced settings')}>
-                    <AdvancedQuestionOptions item={props.item} parentArray={props.parentArray} />
+                    <AdvancedQuestionOptions
+                        item={props.item}
+                        parentArray={props.parentArray}
+                        conditionalArray={props.conditionalArray}
+                        getItem={props.getItem}
+                    />
                 </Accordion>
             </div>
         </div>

--- a/src/helpers/extensionHelper.ts
+++ b/src/helpers/extensionHelper.ts
@@ -83,6 +83,10 @@ export const hasExtension = (extensionParent: Element | undefined, extensionType
     return false;
 };
 
+export const getExtensionStringValue = (item: QuestionnaireItem, extensionType: IExtentionType): string | undefined => {
+    return item.extension?.find((f: Extension) => f.url === extensionType)?.valueString;
+};
+
 export const createGuidanceActionExtension = (valueString = ''): Extension => ({
     url: IExtentionType.guidanceAction,
     valueString,

--- a/src/helpers/itemControl.ts
+++ b/src/helpers/itemControl.ts
@@ -19,6 +19,7 @@ export enum ItemControlType {
     year = 'year',
     receiverComponent = 'receiver-component',
     dynamic = 'dynamic',
+    dataReceiver = 'data-receiver',
 }
 
 export const createItemControlExtension = (itemControlType: ItemControlType): Extension => {
@@ -142,6 +143,10 @@ export const isItemControlSummary = (item: QuestionnaireItem): boolean => {
 
 export const isItemControlSummaryContainer = (item: QuestionnaireItem): boolean => {
     return existItemControlWithCode(item, ItemControlType.summaryContainer);
+};
+
+export const isItemControlDataReceiver = (item: QuestionnaireItem): boolean => {
+    return existItemControlWithCode(item, ItemControlType.dataReceiver);
 };
 
 export const getHelpText = (item: QuestionnaireItem): string => {

--- a/src/locales/fr-FR/translation.json
+++ b/src/locales/fr-FR/translation.json
@@ -392,5 +392,7 @@
     "Display in form filler and PDF": "Affichage sous forme et PDF",
     "Display only in PDF": "Afficher uniquement en PDF",
     "Display only in form filler": "Afficher uniquement dans le formulaire",
-    "Hide in form filler and PDF": "Masquer dans le formulaire et le PDF"
+    "Hide in form filler and PDF": "Masquer dans le formulaire et le PDF",    
+    "Retrieve input data from field": "Récupérer les données d'entrée du champ",
+    "data receiver does not have an earlier question": "le destinataire des données n'a pas de question antérieure"
 }

--- a/src/locales/nb-NO/translation.json
+++ b/src/locales/nb-NO/translation.json
@@ -392,5 +392,7 @@
     "Display in form filler and PDF": "Vises i skjemautfyller og PDF",
     "Display only in PDF": "Vises kun i PDF",
     "Display only in form filler": "Vises kun i skjemautfyller",
-    "Hide in form filler and PDF": "Skjules i skjemautfyller og PDF"
+    "Hide in form filler and PDF": "Skjules i skjemautfyller og PDF",
+    "Retrieve input data from field": "Hent inputdata fra felt",
+    "data receiver does not have an earlier question": "datamottaker har ikke et tidligere spørsmål"
 }

--- a/src/types/IQuestionnareItemType.ts
+++ b/src/types/IQuestionnareItemType.ts
@@ -119,6 +119,7 @@ export enum IExtentionType {
     printVersion = 'http://helsenorge.no/fhir/StructureDefinition/sdf-questionnaire-print-version',
     hyperlinkTarget = 'http://helsenorge.no/fhir/StructureDefinition/sdf-hyperlink-target',
     globalVisibility = 'http://helsenorge.no/fhir/StructureDefintion/sdf-itemControl-visibility',
+    copyExpression = 'http://hl7.org/fhir/StructureDefinition/cqf-expression',
 }
 
 export enum UseContextSystem {


### PR DESCRIPTION
In many situations, there is a need to copy data elements and content in several places in the form, as well as make lookups and calculations based on data in one place, which will have consequences in another place.

A complicating factor that must be taken into account are repetitive elements. For example, a resident states various allergies or medicines, and you want these copied to another field in a summary for healthcare personnel.

**Examples:**

- HSØ needs some key data to be copied into a separate summary for healthcare personnel, so that they can read relevant data that is critical to get a quick overview of.

- HV has a need that corresponds to that of HSØ. In addition, it is desired that a number of calculations are made across the form, where different fhir-path expressions are used.