### PR TITLE
Bug: Do not set readonly to false when is not data-receiver

### DIFF
--- a/src/components/AdvancedQuestionOptions/CopyFrom/CopyFrom.tsx
+++ b/src/components/AdvancedQuestionOptions/CopyFrom/CopyFrom.tsx
@@ -61,8 +61,9 @@ const CopyFrom = (props: CopyFromProps): JSX.Element => {
         if (!props.isDataReceiver) {
             removeCopyExpression();
             setSelectedvalue(undefined);
+        } else {
+            updateReadonlyItem(props.isDataReceiver);
         }
-        updateReadonlyItem(props.isDataReceiver);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.isDataReceiver]);
 


### PR DESCRIPTION
If item is not Data-receiver, readonly should be set to false after Advanced component load