### PR TITLE
Fixes/add condition when language isn't selected

### DIFF
--- a/src/components/Languages/LanguageAccordion.tsx
+++ b/src/components/Languages/LanguageAccordion.tsx
@@ -39,6 +39,8 @@ const LanguageAccordion = (props: LanguageAccordionProps): JSX.Element => {
     }
 
     const dispatchAddLanguage = (selectedLanguage: string, translation: Translation) => {
+        if (!selectedLanguage) return;
+
         const isoLanguage = languageToIsoString(selectedLanguage);
         if (isoLanguage && qAdditionalLanguages !== undefined && !qAdditionalLanguages[isoLanguage]) {
             dispatch(addQuestionnaireLanguageAction(isoLanguage, translation));


### PR DESCRIPTION
**Issue**
- App was breaking when user doesn't select any language and clicks on add new language.
<img width="1226" alt="Screenshot 2024-08-08 at 1 58 50 PM" src="https://github.com/user-attachments/assets/370ce586-780b-4acd-acda-ac3ead8d610b">

**Done**
- Fixed the issue by adding the condition when any language isn't selected.
